### PR TITLE
invocation and readonly test

### DIFF
--- a/src/main/java/com/example/pharmacy/pharmacy/service/PharmacyRepositoryService.java
+++ b/src/main/java/com/example/pharmacy/pharmacy/service/PharmacyRepositoryService.java
@@ -19,13 +19,15 @@ public class PharmacyRepositoryService {
 
     private final PharmacyRepository pharmacyRepository;
 
-    // self invocation test
-    // 원인
-    // 같은 클래스 내에서 같은 클래스의 @Transactional이 붙은 메서드를 호출하면 발생
-    // proxy 객체를 사용하기 때문에 같은 클래스 내에서 호출하면 proxy 객체를 사용하지 않고 호출된다.
-    // 해결방법들
-    // 1. 상위 메서드에 @Transactional을 붙인다.
-    // 2. 의존성 분리를 한다. -> foo 함수를 별도의 서비스 클래스의 함수로 분리한다.
+    /* self invocation test
+     원인
+     같은 클래스 내에서 상위 메서드에 @Transactional 을 붙이지 않고, 같은 클래스의 @Transactional이 붙은 메서드를 호출하면 발생
+     같은 클래스 내의 메서드를 호출하면 proxy 객체를 사용하지 않고 호출하기 때문에 발생
+     pr 에 정리완료
+     해결방법들
+     1. 상위 메서드에 @Transactional을 붙인다.
+     2. 의존성 분리를 한다. -> foo 함수를 별도의 서비스 클래스의 함수로 분리한다.
+     */
     // @Transactional
     public void bar(List<Pharmacy> pharmacies) {
         log.info("bar CurrentTransactionName: "+ TransactionSynchronizationManager.getCurrentTransactionName());

--- a/src/main/java/com/example/pharmacy/pharmacy/service/PharmacyRepositoryService.java
+++ b/src/main/java/com/example/pharmacy/pharmacy/service/PharmacyRepositoryService.java
@@ -5,9 +5,12 @@ import com.example.pharmacy.pharmacy.repository.PharmacyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 import java.util.Objects;
+
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -15,6 +18,35 @@ import java.util.Objects;
 public class PharmacyRepositoryService {
 
     private final PharmacyRepository pharmacyRepository;
+
+    // self invocation test
+    // 원인
+    // 같은 클래스 내에서 같은 클래스의 @Transactional이 붙은 메서드를 호출하면 발생
+    // proxy 객체를 사용하기 때문에 같은 클래스 내에서 호출하면 proxy 객체를 사용하지 않고 호출된다.
+    // 해결방법들
+    // 1. 상위 메서드에 @Transactional을 붙인다.
+    // 2. 의존성 분리를 한다. -> foo 함수를 별도의 서비스 클래스의 함수로 분리한다.
+    // @Transactional
+    public void bar(List<Pharmacy> pharmacies) {
+        log.info("bar CurrentTransactionName: "+ TransactionSynchronizationManager.getCurrentTransactionName());
+        foo(pharmacies);
+    }
+
+    @Transactional
+    public void foo(List<Pharmacy> pharmacies) {
+        log.info("foo CurrentTransactionName: "+ TransactionSynchronizationManager.getCurrentTransactionName());
+        pharmacies.forEach(pharmacy -> {
+            pharmacyRepository.save(pharmacy);
+            throw new RuntimeException("error"); // 예외 발생
+        });
+    }
+
+    // read only test
+    @Transactional(readOnly = true)
+    public void readOnlyTest(Long id) {
+        pharmacyRepository.findById(id).ifPresent(pharmacy ->
+                pharmacy.changePharmacyAddress("서울 특별시 강남구 역삼동"));
+    }
 
     @Transactional
     public void updateAddress(Long id, String address) {


### PR DESCRIPTION
## 작업내용
1. spring self invocation 관련 내용 학습 및 테스트
- 메소드가 호출되는 시점에 프록시 객체를 생성하고, 프록시 객체는 부가기능(트랜잭션)을 주입해 준다.
- bar 에 @Transactional을 안붙여주면?
   - proxy 객체가 생성되지 않고
   - 내부호출(foo 호출)에 대해서는 proxy객체가 동작하지 않는다( 같은 클래스 내에서 호출하면 proxy 객체를 사용하지 않고 호출된다 )
   - 결과적으로 트랜잭션 동작 안하므로 롤백도 정상적으로 안됨
- 해결방법
   1.  상위 메서드에 @Transactional을 붙인다.
   2. 의존성 분리를 한다. -> foo 함수를 별도의 서비스 클래스의 함수로 분리한다.
3. spring transaction readOnly 관련 내용 학습 => readOnly 로 되어있으면 dirty checking 을 안하므로 성능이 소폭 향상되고, 변경 감지를 안하게 됨. 즉, 수정사항이 반영되지 않는다. 
4. readOnly 옵션 쓰려면 `import org.springframework.transaction.annotation.Transactional;` 요걸 임포트 받아야 함
 